### PR TITLE
Update kfold_gen.m

### DIFF
--- a/src/tests/machine_learning_codes/kfold_gen.m
+++ b/src/tests/machine_learning_codes/kfold_gen.m
@@ -30,7 +30,7 @@ else
     else
         for c = 1:params.nbClasses
             iCurrentClass = find(labels == c);
-            iCurrentClass = randperm(length(iCurrentClass));
+            iCurrentClass = iCurrentClass(randperm(length(iCurrentClass)))';
             nbTrialsPerClass(c) = length(iCurrentClass);
             nbTrialsPerFold = round(nbTrialsPerClass(c) / params.nbFolds); %imprecision si le nombre de trial par classe n'est pas divisible par k (params.nbFolds)
             %On ajoute les indexes pour diviser en k-1 folds


### PR DESCRIPTION
change  "iCurrentClass = randperm(length(iCurrentClass));" (line 33) by "iCurrentClass = iCurrentClass(randperm(length(iCurrentClass)))';"
The generated folds were being generated only in one half of the labels, and so, the testing process, when applying svm_rbf for example, were being tested in one half, i.e. when the labels_train are 16, the generated folds have only from 1 to 8, and so, the testing process were done only with those but not over the others (9-16).