### PR TITLE
Update GSR_feat_extr.m

### DIFF
--- a/src/signals/GSR/features/GSR_feat_extr.m
+++ b/src/signals/GSR/features/GSR_feat_extr.m
@@ -69,7 +69,7 @@ if(~isempty(GSR_feats_names))
 	if any(strcmp('nbPeaks',GSR_feats_names)) || any(strcmp('ampPeaks',GSR_feats_names)) || any(strcmp('riseTime',GSR_feats_names))
 		
 		[nbPeaks, ampPeaks, riseTime, posPeaks] = GSR_feat_peaks(GSRsignal,ampThresh);
-		nbPeaks = nbPeaks/(length(GSRsignal)/samprate);
+		nbPeaks = nbPeaks/(length(GSRsignal.raw)/samprate);
 		ampPeaks = mean(ampPeaks);
 		riseTime = mean(riseTime);
 		%TODO what is this good for? posPeaks


### PR DESCRIPTION
Just a minor change as the original code for calculating the number of GSR peaks per second was incorrect with `nbPeaks = nbPeaks/(length(GSRsignal)/samprate);` since `length(GSRsignal)` always equals 1.

It should be `nbPeaks = nbPeaks/(length(GSRsignal.raw)/samprate);` to get the correct number.